### PR TITLE
adding config to trigger after image load event

### DIFF
--- a/lazysizes.js
+++ b/lazysizes.js
@@ -415,6 +415,10 @@
 
 						addClass(elem, lazySizesConfig.loadingClass);
 						addRemoveLoadEvents(elem, switchLoadingClass, true);
+
+						if (lazySizesConfig.afterLoadEvent) {
+							triggerEvent(e.target, 'imageLazyLoaded');
+						}
 					}
 
 					if(isPicture){
@@ -646,7 +650,8 @@
 			init: true,
 			expFactor: 1.7,
 			hFac: 0.8,
-			loadMode: 2
+			loadMode: 2,
+			afterLoadEvent: false
 		};
 
 		lazySizesConfig = window.lazySizesConfig || window.lazysizesConfig || {};


### PR DESCRIPTION
Adding a config that, if set to `true`, triggers an event right after a given image is lazy loaded
